### PR TITLE
Allow use with capistrano 3.1

### DIFF
--- a/mascherano.gemspec
+++ b/mascherano.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "capistrano", "~> 3.0.0"
+  spec.add_dependency "capistrano", "~> 3.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
This is fairly straightforward, but I would like to use mascherano with cap 3.1, so this PR loosens the dependency to allow for 3.1+.
