### PR TITLE
Allow the upstart command to be customized

### DIFF
--- a/lib/mascherano/tasks/upstart.cap
+++ b/lib/mascherano/tasks/upstart.cap
@@ -1,32 +1,43 @@
-def build_cmd(service_name, action, sudo = false)
-  cmd = "service #{service_name} #{action}"
-  cmd = "sudo " + cmd if sudo
-  cmd
-end
-
 namespace :upstart do
+
+  def as_configured_user
+    if fetch(:upstart_sudo)
+      as(:root) { yield }
+    else
+      yield
+    end
+  end
+
+  def upstart_cmd; fetch(:upstart_cmd) end
+  def upstart_roles; fetch(:upstart_roles) end
+  def upstart_service; fetch(:upstart_service) end
+
   desc "Start the application services"
   task :start do
-    on roles(fetch(:upstart_roles)) do
-      execute build_cmd(fetch(:upstart_service), 'start', fetch(:upstart_sudo))
+    on roles(upstart_roles) do
+      as_configured_user do
+        execute upstart_cmd, 'start', upstart_service
+      end
     end
   end
 
   desc "Stop the application services"
   task :stop do
-    on roles(fetch(:upstart_roles)) do
-      execute build_cmd(fetch(:upstart_service), 'stop', fetch(:upstart_sudo))
+    on roles(upstart_roles) do
+      as_configured_user do
+        execute upstart_cmd 'stop', upstart_service
+      end
     end
   end
 
   desc "Restart the application services"
   task :restart do
-    on roles(fetch(:upstart_roles)) do
-      cmd_sq  = build_cmd(fetch(:upstart_service), 'start', fetch(:upstart_sudo))
-      cmd_sq += ' || '
-      cmd_sq += build_cmd(fetch(:upstart_service), 'restart', fetch(:upstart_sudo))
-
-      execute cmd_sq
+    on roles(upstart_roles) do
+      as_configured_user do
+        unless test(upstart_cmd, 'start', upstart_service)
+          execute upstart_cmd, 'restart', upstart_service
+        end
+      end
     end
   end
 end
@@ -36,6 +47,7 @@ namespace :load do
     set :upstart_service, -> { fetch(:application) }
     set :upstart_sudo, false
     set :upstart_roles, :app
+    set :upstart_cmd, 'initctl'
   end
 end
 


### PR DESCRIPTION
In my usecase, I am using [user jobs](http://upstart.ubuntu.com/cookbook/#user-job) to control the
application. This allows me to avoid giving sudo access to the deploy
user; however, by default the deploy user does not have `/sbin` in the
`$PATH`. This change allows me to set `upstart_cmd` to `/sbin/initctl`
so the deploy user can start/stop the app. It also provides better
integration with the command mappings in SSHKit by using a single
command (`initctl`) and calling execute in a way that allows the command
to be properly identified.
