### PR TITLE
Honor the :no_release setting on a server

### DIFF
--- a/lib/mascherano/tasks/auth_basic.cap
+++ b/lib/mascherano/tasks/auth_basic.cap
@@ -10,7 +10,7 @@ namespace :auth_basic do
       htpasswd.chomp!
     end
 
-    on roles(fetch(:auth_basic_roles)) do
+    on fetch(:auth_basic_servers) do
       upload! StringIO.new(htpasswd), fetch(:auth_basic_target)
       execute :chmod, 'o+r', fetch(:auth_basic_target)
     end
@@ -19,8 +19,9 @@ end
 
 namespace :load do
   task :defaults do
-    set :auth_basic_user, 'root'
-    set :auth_basic_roles, :all
-    set :auth_basic_target, -> { shared_path.join('.htpasswd') }
+    set :auth_basic_user,     'root'
+    set :auth_basic_roles,    :all
+    set :auth_basic_servers,  -> { release_roles(fetch(:auth_basic_roles)) }
+    set :auth_basic_target,   -> { shared_path.join('.htpasswd') }
   end
 end

--- a/lib/mascherano/tasks/env.cap
+++ b/lib/mascherano/tasks/env.cap
@@ -4,12 +4,13 @@ namespace :env do
 
     You can override any of these defaults by setting the variables shown below.
 
-    set :env_file, ".env"
-    set :env_roles, :all
-    set :target_file, -> { shared_path.join('.env') }
+    set :env_file,     ".env"
+    set :env_roles,    :all
+    set :env_servers,  -> { release_roles(fetch(:env_roles)) }
+    set :env_target,   -> { shared_path.join('.env') }
   DESC
   task :upload do
-    on roles(fetch(:env_roles)) do
+    on fetch(:env_servers) do
       upload! fetch(:env_file), fetch(:env_target)
     end
   end
@@ -18,7 +19,7 @@ namespace :env do
     Symlink the .env file to the release_path
   DESC
   task :symlink do
-    on roles(fetch(:env_roles)) do
+    on fetch(:env_servers) do
       execute :ln, '-sf', fetch(:env_target), release_path.join('.env')
     end
   end
@@ -26,9 +27,10 @@ end
 
 namespace :load do
   task :defaults do
-    set :env_file, ".env"
-    set :env_roles, :all
-    set :env_target, -> { shared_path.join('.env') }
+    set :env_file,     ".env"
+    set :env_roles,    :all
+    set :env_servers,  -> { release_roles(fetch(:env_roles)) }
+    set :env_target,   -> { shared_path.join('.env') }
   end
 end
 

--- a/lib/mascherano/tasks/figaro.cap
+++ b/lib/mascherano/tasks/figaro.cap
@@ -6,9 +6,11 @@ namespace :figaro do
 
     You can override any of these defaults by setting the variables shown below.
 
-    set :figaro_target, -> { shared_path.join('application.yml') }
-    set :figaro_config, -> { release_path.join('config', 'application.yml') }
-    set :figaro_to_env, false
+    set :figaro_target,   -> { shared_path.join('application.yml') }
+    set :figaro_config,   -> { release_path.join('config',            'application.yml') }
+    set :figaro_to_env,   false
+    set :figaro_roles,    :app
+    set :figaro_servers,  -> { release_roles(fetch(:figaro_roles)) }
   DESC
   task :upload do
     figaro_data = nil
@@ -27,7 +29,7 @@ namespace :figaro do
     end
 
     if figaro_data
-      on roles(fetch(:figaro_roles)) do
+      on fetch(:figaro_servers) do
         upload! StringIO.new(figaro_data), fetch(:figaro_target)
       end
     end
@@ -37,7 +39,7 @@ namespace :figaro do
     Symlink the application config to the release_path
   DESC
   task :symlink do
-    on roles(fetch(:figaro_roles)) do
+    on fetch(:figaro_servers) do
       execute :ln, '-sf', fetch(:figaro_target), fetch(:figaro_config)
     end
   end
@@ -45,10 +47,11 @@ end
 
 namespace :load do
   task :defaults do
-    set :figaro_target, -> { shared_path.join('application.yml') }
-    set :figaro_config, -> { release_path.join('config', 'application.yml') }
-    set :figaro_to_env, false
-    set :figaro_roles, :app
+    set :figaro_target,   -> { shared_path.join('application.yml') }
+    set :figaro_config,   -> { release_path.join('config',            'application.yml') }
+    set :figaro_to_env,   false
+    set :figaro_roles,    :app
+    set :figaro_servers,  -> { release_roles(fetch(:figaro_roles)) }
   end
 end
 

--- a/lib/mascherano/tasks/foreman.cap
+++ b/lib/mascherano/tasks/foreman.cap
@@ -4,23 +4,23 @@ namespace :foreman do
 
     You can override any of these defaults by setting the variables shown below.
 
-    set :foreman_cmd,         "foreman"
-    set :foreman_format,      "upstart"
-    set :foreman_location,    "/etc/init"
-    set :foreman_port,        5000
-    set :foreman_root,        -> { release_path }
-    set :foreman_procfile,    -> { release_path.join('Procfile') }
-    set :foreman_app,         -> { fetch(:application) }
-    set :foreman_user,        -> { host.user }
-    set :foreman_log,         -> { shared_path.join('log') }
-    set :foreman_pids,        false
-    set :foreman_concurrency, false
-    set :foreman_sudo,        false
-    set :foreman_roles,       :all
+    set :foreman_cmd,          "foreman"
+    set :foreman_format,       "upstart"
+    set :foreman_location,     "/etc/init"
+    set :foreman_port,         5000
+    set :foreman_root,         -> { release_path }
+    set :foreman_procfile,     -> { release_path.join('Procfile') }
+    set :foreman_app,          -> { fetch(:application) }
+    set :foreman_log,          -> { shared_path.join('log') }
+    set :foreman_pids,         false
+    set :foreman_concurrency,  false
+    set :foreman_sudo,         false
+    set :foreman_roles,        :all
+    set :foreman_servers,      -> { release_roles(fetch(:foreman_roles)) }
   DESC
 
   task :export do
-    on roles(fetch(:foreman_roles)) do |host|
+    on fetch(:foreman_servers) do |host|
       within release_path do
         foreman_cmd         = fetch(:foreman_cmd)
         foreman_concurrency = fetch(:foreman_concurrency)
@@ -52,18 +52,19 @@ end
 
 namespace :load do
   task :defaults do
-    set :foreman_cmd,         "foreman"
-    set :foreman_format,      "upstart"
-    set :foreman_location,    "/etc/init"
-    set :foreman_port,        5000
-    set :foreman_root,        -> { release_path }
-    set :foreman_procfile,    -> { release_path.join('Procfile') }
-    set :foreman_app,         -> { fetch(:application) }
-    set :foreman_log,         -> { shared_path.join('log') }
-    set :foreman_pids,        false
-    set :foreman_concurrency, false
-    set :foreman_sudo,        false
-    set :foreman_roles,       :all
+    set :foreman_cmd,          "foreman"
+    set :foreman_format,       "upstart"
+    set :foreman_location,     "/etc/init"
+    set :foreman_port,         5000
+    set :foreman_root,         -> { release_path }
+    set :foreman_procfile,     -> { release_path.join('Procfile') }
+    set :foreman_app,          -> { fetch(:application) }
+    set :foreman_log,          -> { shared_path.join('log') }
+    set :foreman_pids,         false
+    set :foreman_concurrency,  false
+    set :foreman_sudo,         false
+    set :foreman_roles,        :all
+    set :foreman_servers,      -> { release_roles(fetch(:foreman_roles)) }
   end
 end
 

--- a/lib/mascherano/tasks/go.cap
+++ b/lib/mascherano/tasks/go.cap
@@ -4,15 +4,16 @@ namespace :go do
 
     You can override any of these defaults by setting the variables shown below.
 
-    set :go_input,  'api.go'
-    set :go_output, 'api'
-    set :go_os,     'linux'
-    set :go_arch,   'amd64'
-    set :go_roles,  :app
-    set :go_target, -> { release_path.join(fetch(:go_output)) }
+    set :go_input,    'api.go'
+    set :go_output,   'api'
+    set :go_os,       'linux'
+    set :go_arch,     'amd64'
+    set :go_roles,    :app
+    set :go_servers,  -> { release_roles(fetch(:go_roles)) }
+    set :go_target,   -> { release_path.join(fetch(:go_output)) }
   DESC
   task :build do
-    on roles(fetch(:go_roles)) do
+    on fetch(:go_servers) do
       run_locally do
         go_flags = {
           'GOOS'   => fetch(:go_os),
@@ -28,7 +29,7 @@ namespace :go do
 
   desc 'Upload compiled application to the server'
   task :upload do
-    on roles(fetch(:go_roles)) do
+    on fetch(:go_servers) do
       upload! fetch(:go_output), fetch(:go_target)
     end
   end
@@ -36,11 +37,12 @@ end
 
 namespace :load do
   task :defaults do
-    set :go_input,  'api.go'
-    set :go_output, 'api'
-    set :go_os,     'linux'
-    set :go_arch,   'amd64'
-    set :go_roles,  :app
-    set :go_target, -> { release_path.join(fetch(:go_output)) }
+    set :go_input,    'api.go'
+    set :go_output,   'api'
+    set :go_os,       'linux'
+    set :go_arch,     'amd64'
+    set :go_roles,    :app
+    set :go_servers,  -> { release_roles(fetch(:go_roles)) }
+    set :go_target,   -> { release_path.join(fetch(:go_output)) }
   end
 end

--- a/lib/mascherano/tasks/supervisor.cap
+++ b/lib/mascherano/tasks/supervisor.cap
@@ -31,7 +31,7 @@ namespace :supervisor do
     end
 
     if supervisor_config
-      on roles(fetch(:supervisor_roles)) do
+      on fetch(:supervisor_servers) do
         upload! StringIO.new(supervisor_config), fetch(:supervisor_target)
       end
     end
@@ -39,35 +39,35 @@ namespace :supervisor do
 
   desc 'Symlink supervisord config to the conf.d'
   task :symlink do
-    on roles(fetch(:supervisor_roles)) do
+    on fetch(:supervisor_servers) do
       execute :ln, '-sf', fetch(:supervisor_target), fetch(:supervisor_confd)
     end
   end
 
   desc 'Reread supervisord'
   task :reread do
-    on roles(fetch(:supervisor_roles)) do
+    on fetch(:supervisor_servers) do
       execute :supervisorctl, 'reread'
     end
   end
 
   desc 'Update supervisord'
   task :update do
-    on roles(fetch(:supervisor_roles)) do
+    on fetch(:supervisor_servers) do
       execute :supervisorctl, 'update'
     end
   end
 
   desc 'Restart application'
   task :restart do
-    on roles(fetch(:supervisor_roles)) do
+    on fetch(:supervisor_servers) do
       execute :supervisorctl, 'restart', "#{fetch(:supervisor_application)}:*"
     end
   end
 
   desc 'Update configuration or restart application'
   task :refresh do
-    on roles(fetch(:supervisor_roles)) do
+    on fetch(:supervisor_servers) do
       if test "supervisorctl reread | grep 'No config updates to processes'"
         execute :supervisorctl, 'restart', "#{fetch(:supervisor_application)}:*"
       else
@@ -79,12 +79,13 @@ end
 
 namespace :load do
   task :defaults do
-    set :supervisor_application, -> { fetch(:application) }
-    set :supervisor_stage,       -> { fetch(:stage) }
-    set :supervisor_template,    -> { "config/supervisor/#{fetch(:supervisor_stage)}.conf" }
-    set :supervisor_target,      -> { shared_path.join('supervisord.conf') }
-    set :supervisor_confd,       -> { "/etc/supervisor/conf.d/#{fetch(:supervisor_application)}.conf" }
-    set :supervisor_roles,       :all
+    set :supervisor_application,  -> { fetch(:application) }
+    set :supervisor_stage,        -> { fetch(:stage) }
+    set :supervisor_template,     -> { "config/supervisor/#{fetch(:supervisor_stage)}.conf" }
+    set :supervisor_target,       -> { shared_path.join('supervisord.conf') }
+    set :supervisor_confd,        -> { "/etc/supervisor/conf.d/#{fetch(:supervisor_application)}.conf" }
+    set :supervisor_roles,        :all
+    set :supervisor_servers,      -> { release_roles(fetch(:supervisor_roles)) }
   end
 end
 

--- a/lib/mascherano/tasks/token.cap
+++ b/lib/mascherano/tasks/token.cap
@@ -8,14 +8,14 @@ end
 namespace :token do
   desc 'Generate random token'
   task :generate do
-    on roles(fetch(:token_roles)) do
+    on fetch(:token_servers) do
       info generate_token(fetch(:token_length))
     end
   end
 
   desc 'Upload random token as a file on remote server'
   task :upload do
-    on roles(fetch(:token_roles)) do
+    on fetch(:token_servers) do
       token = generate_token(fetch(:token_length))
       io    = StringIO.new(token)
       upload! io, fetch(:token_target)
@@ -28,6 +28,7 @@ namespace :load do
     set :token_length, 64
     set :token_target, -> { shared_path.join('.token') }
     set :token_roles, :app
+    set :token_servers,  -> { release_roles(fetch(:token_roles)) }
   end
 end
 

--- a/lib/mascherano/tasks/upstart.cap
+++ b/lib/mascherano/tasks/upstart.cap
@@ -14,7 +14,7 @@ namespace :upstart do
 
   desc "Start the application services"
   task :start do
-    on roles(upstart_roles) do
+    on fetch(:upstart_servers) do
       as_configured_user do
         execute upstart_cmd, 'start', upstart_service
       end
@@ -23,7 +23,7 @@ namespace :upstart do
 
   desc "Stop the application services"
   task :stop do
-    on roles(upstart_roles) do
+    on fetch(:upstart_servers) do
       as_configured_user do
         execute upstart_cmd 'stop', upstart_service
       end
@@ -32,7 +32,7 @@ namespace :upstart do
 
   desc "Restart the application services"
   task :restart do
-    on roles(upstart_roles) do
+    on fetch(:upstart_servers) do
       as_configured_user do
         unless test(upstart_cmd, 'start', upstart_service)
           execute upstart_cmd, 'restart', upstart_service
@@ -44,10 +44,11 @@ end
 
 namespace :load do
   task :defaults do
-    set :upstart_service, -> { fetch(:application) }
-    set :upstart_sudo, false
-    set :upstart_roles, :app
-    set :upstart_cmd, 'initctl'
+    set :upstart_service,  -> { fetch(:application) }
+    set :upstart_sudo,     false
+    set :upstart_roles,    :app
+    set :upstart_servers,  -> { release_roles(fetch(:upstart_roles)) }
+    set :upstart_cmd,      'initctl'
   end
 end
 


### PR DESCRIPTION
This allows a user to flag a server with `:no_release => true` to bypass
relase tasks. This patter was copied from [capistrano/bundler](https://github.com/capistrano/bundler/blob/master/lib/capistrano/tasks/bundler.cap#L64-L65)
