### PR TITLE
Prefer sudo over as(:root)

### DIFF
--- a/lib/mascherano/tasks/foreman.cap
+++ b/lib/mascherano/tasks/foreman.cap
@@ -40,14 +40,22 @@ namespace :foreman do
         cmd << %Q(-r #{foreman_pids}) if foreman_pids
         cmd << %Q(-c #{foreman_concurrency}) if foreman_concurrency
 
-        if foreman_sudo
-          as(:root) { execute *cmd }
-        else
-          execute *cmd
-        end
+        execute *cmd
       end
     end
   end
+
+  desc 'Prefixes the foreman command with sudo when :foreman_sudo => true'
+  task :configure_sudo do
+    if fetch(:foreman_sudo)
+      foreman_cmd = fetch(:foreman_cmd).to_s
+      SSHKit.config.command_map.prefix[foreman_cmd].push('sudo')
+    end
+  end
+end
+
+Capistrano::DSL.stages.each do |stage|
+  after stage, 'foreman:configure_sudo'
 end
 
 namespace :load do

--- a/lib/mascherano/tasks/upstart.cap
+++ b/lib/mascherano/tasks/upstart.cap
@@ -1,45 +1,38 @@
 namespace :upstart do
-
-  def as_configured_user
-    if fetch(:upstart_sudo)
-      as(:root) { yield }
-    else
-      yield
-    end
-  end
-
-  def upstart_cmd; fetch(:upstart_cmd) end
-  def upstart_roles; fetch(:upstart_roles) end
-  def upstart_service; fetch(:upstart_service) end
-
   desc "Start the application services"
   task :start do
     on fetch(:upstart_servers) do
-      as_configured_user do
-        execute upstart_cmd, 'start', upstart_service
-      end
+      execute fetch(:upstart_cmd), 'start', fetch(:upstart_service)
     end
   end
 
   desc "Stop the application services"
   task :stop do
     on fetch(:upstart_servers) do
-      as_configured_user do
-        execute upstart_cmd 'stop', upstart_service
-      end
+      execute fetch(:upstart_cmd), 'stop', fetch(:upstart_service)
     end
   end
 
   desc "Restart the application services"
   task :restart do
     on fetch(:upstart_servers) do
-      as_configured_user do
-        unless test(upstart_cmd, 'start', upstart_service)
-          execute upstart_cmd, 'restart', upstart_service
-        end
+      unless test(fetch(:upstart_cmd), 'start', fetch(:upstart_service))
+        execute fetch(:upstart_cmd), 'restart', fetch(:upstart_service)
       end
     end
   end
+
+  desc "Prefixes the upstart command with sudo when :upstart_sudo => true"
+  task :configure_sudo do
+    if fetch(:upstart_sudo)
+      upstart_cmd = fetch(:upstart_cmd).to_s
+      SSHKit.config.command_map.prefix[upstart_cmd].push('sudo')
+    end
+  end
+end
+
+Capistrano::DSL.stages.each do |stage|
+  after stage, 'upstart:configure_sudo'
 end
 
 namespace :load do


### PR DESCRIPTION
Using `sudo` should be safer in practice because it is easy to control
through the sudoers file. `as(:root)` requires unlimited access to the
root user, which is probably not what we want.

This reverts foreman and upstart back to using `sudo`, but the
implementation relies on SSHKit's command map prefixes. This eliminates
the need to branch in each task that needs the optional `sudo`.

@subosito, after going down this path a ways I realized that the change I made going from `sudo` to `as(:root)` was not ideal because it meant the deployer user needed full access to the root user. I added `upstart:configure_sudo` and `foreman:configure:sudo` tasks, which will run immediately after the "stage" task. These new tasks add `sudo` as a prefix to the configured command if the user sets the flag to use `sudo`. Let me know if you have any questions. Sorry for the mistake.
