### PR TITLE
noscm to support Capistrano 3.2+

### DIFF
--- a/lib/capistrano/tasks/noscm.cap
+++ b/lib/capistrano/tasks/noscm.cap
@@ -5,4 +5,5 @@ namespace :noscm do
       execute :mkdir, '-p', release_path
     end
   end
+  task :set_current_revision do; end
 end


### PR DESCRIPTION
Added empty `noscm:set_current_revision` rake task which is called by `deploy:updating` in Capistrano versions 3.2.0 and above ([see commit b1cbb0c](https://github.com/capistrano/capistrano/commit/b1cbb0cd54ed79960ccee0feab52ead209512858#diff-aa4465f31474e46370f8f1f204f7d51eR9)).

Tested noscm against Capistrano 3.1.0, 3.2.1, 3.3.5 and 3.4.0. :grin:
